### PR TITLE
Setting form type implementation

### DIFF
--- a/src/Roadkill.Core/Plugins/SettingFormType.cs
+++ b/src/Roadkill.Core/Plugins/SettingFormType.cs
@@ -21,6 +21,10 @@ namespace Roadkill.Core.Plugins
 		/// <summary>
 		/// A textarea.
 		/// </summary>
-		Textarea = 2
+		Textarea = 2,
+        /// <summary>
+        /// A password box.
+        /// </summary>
+        Password = 3
 	}
 }

--- a/src/Roadkill.Core/Plugins/SettingValue.cs
+++ b/src/Roadkill.Core/Plugins/SettingValue.cs
@@ -10,19 +10,54 @@ namespace Roadkill.Core.Plugins
 	/// </summary>
 	public class SettingValue
 	{
-		/// <summary>
+	    private string _value;
+	    private SettingFormType _formType;
+
+	    /// <summary>
 		/// The setting name.
 		/// </summary>
 		public string Name { get; set; }
 
-		/// <summary>
-		/// The setting value.
-		/// </summary>
-		public string Value { get; set; }
+	    /// <summary>
+	    /// The setting value.
+	    /// </summary>
+	    public string Value
+	    {
+	        get { return _value; }
+	        set { _value = GetCleanValue(value, FormType); }
+	    }
 
-		/// <summary>
-		/// The UI type that should be used to represent the value (not currently implemented).
-		/// </summary>
-		public SettingFormType FormType { get; set; }
+	    /// <summary>
+	    /// The UI type that should be used to represent the value.
+	    /// </summary>
+	    public SettingFormType FormType
+	    {
+	        get { return _formType; }
+	        set
+	        {
+                _formType = value;
+                // Re-set Value to make sure it conforms to new type
+	            Value = Value;
+	        }
+	    }
+
+	    private static string GetCleanValue(string input, SettingFormType formType)
+	    {
+            switch (formType)
+            {
+                case SettingFormType.Checkbox:
+                    // Checkbox should be boolean.
+                    // The whole settings could be reworked as a generic class,
+                    // quite easy with JSON serialization, but for now let's just see
+                    // if the value provided by plugin creator is boolean, and if not -
+                    // - revert to default (which was, is, and probably will be False)
+                    bool o;
+                    if (!bool.TryParse(input, out o))
+                        o = default(bool);
+                    return o.ToString();
+                default:
+                    return input;
+            }
+	    }
 	}
 }

--- a/src/Roadkill.Core/Plugins/Settings.cs
+++ b/src/Roadkill.Core/Plugins/Settings.cs
@@ -69,9 +69,12 @@ namespace Roadkill.Core.Plugins
 				settingValue.Name = name;
 				_values.Add(settingValue);
 			}
-			
-			settingValue.Value = value;
+            
+			// Set form type first, so that the validation happens
+			// Though the after-the-fact validation will work even 
+            // if done other way around.
 			settingValue.FormType = formType;
+            settingValue.Value = value;
 		}
 
 		/// <summary>

--- a/src/Roadkill.Web/Areas/SiteSettings/Views/PluginSettings/Edit.cshtml
+++ b/src/Roadkill.Web/Areas/SiteSettings/Views/PluginSettings/Edit.cshtml
@@ -35,6 +35,9 @@
                     case SettingFormType.Textarea:
                         <textarea rows="5" cols="25" name="SettingValues[@i].Value">Model.SettingValues[i].Value</textarea>
                         break;
+                    case SettingFormType.Password:
+                        <input type="password" name="SettingValues[@i].Value" value="@Model.SettingValues[i].Value"/>
+                        break;
                     default:
                         <input type="text" name="SettingValues[@i].Value" value="@Model.SettingValues[i].Value"/>
                         break;

--- a/src/Roadkill.Web/Areas/SiteSettings/Views/PluginSettings/Edit.cshtml
+++ b/src/Roadkill.Web/Areas/SiteSettings/Views/PluginSettings/Edit.cshtml
@@ -25,9 +25,20 @@
 	    {
 		    <div>
                 <label for="SettingValues[@i].Value">@Model.SettingValues[i].Name</label>
-                    
-                <input type="hidden" name="SettingValues[@i].Name" value="@Model.SettingValues[i].Name" />
-                <input type="text" name="SettingValues[@i].Value" value="@Model.SettingValues[i].Value" />
+
+		        <input type="hidden" name="SettingValues[@i].Name" value="@Model.SettingValues[i].Name"/>
+                @switch (Model.SettingValues[i].FormType)
+                {
+                    case SettingFormType.Checkbox:
+                        @Html.CheckBox(String.Format("SettingValues[{0}].Value", i), bool.Parse(Model.SettingValues[i].Value));
+                        break;
+                    case SettingFormType.Textarea:
+                        <textarea rows="5" cols="25" name="SettingValues[@i].Value">Model.SettingValues[i].Value</textarea>
+                        break;
+                    default:
+                        <input type="text" name="SettingValues[@i].Value" value="@Model.SettingValues[i].Value"/>
+                        break;
+                }
 		    </div>
 	    }
     </fieldset>


### PR DESCRIPTION
I've implemented various setting form types, also included @gandarez Password type. Using a checkbox require conforming to bool.Parse and bool.ToString by plugin creators, but I think it's better than parsing manually some arbitrary constants (like "on/off" or "enabled/disabled"). I'll look into type safety in the future.