### PR TITLE
Improve performance of AD lookup

### DIFF
--- a/src/Roadkill.Core/Security/Windows/ActiveDirectoryUserService.cs
+++ b/src/Roadkill.Core/Security/Windows/ActiveDirectoryUserService.cs
@@ -146,7 +146,7 @@ namespace Roadkill.Core.Security.Windows
 					users.AddRange(GetUsersInGroup(group));
 				}
 
-				return users.Contains(CleanUsername(email));
+				return new HashSet<string>(users).Contains(CleanUsername(email));
 			}
 			catch (Exception ex)
 			{
@@ -172,7 +172,7 @@ namespace Roadkill.Core.Security.Windows
 					users.AddRange(GetUsersInGroup(group));
 				}
 
-				return users.Contains(CleanUsername(email));
+                return new HashSet<string>(users).Contains(CleanUsername(email));
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
We have some performance problems with in combination with the AD. This will take sometimes 20-30 seconds. (after login popup in browser). Without AD integration, it's a lot faster.

I'm not sure if this will fix it, but we have a lot of users and groups, so using a Hashset is always a good idea. 