### PR TITLE
UX improvement for shortcut links like [][this]

### DIFF
--- a/src/Roadkill.Core/Text/MarkupConverter.cs
+++ b/src/Roadkill.Core/Text/MarkupConverter.cs
@@ -284,6 +284,13 @@ namespace Roadkill.Core.Converters
 			{
 				href = UrlResolver.GetInternalUrlForTitle(page.Id, page.Title);
 				href += anchorHash;
+				
+		                //for shortcut links like [][this]
+		                if (string.IsNullOrWhiteSpace(e.Text))
+		                {
+		                    e.Text = page.Title;
+		                }				
+				
 			}
 			else
 			{


### PR DESCRIPTION
DRY. Fill text link when is internal link and text link is missing.

Because roadkillwiki keep links up-to-date on referenced title page changed, it is more easy to let blank text link and only inform internal page destination,  like [][this]
