### PR TITLE
Added support for SVG images

### DIFF
--- a/src/Roadkill.Core/Attachments/MimeTypes.cs
+++ b/src/Roadkill.Core/Attachments/MimeTypes.cs
@@ -167,6 +167,8 @@ namespace Roadkill.Core.Attachments
 			ExtensionMap.Add(".scd", "application/x-msschedule");
 			ExtensionMap.Add(".sst", "application/vndms-pkicertstore");
 			ExtensionMap.Add(".src", "application/x-wais-source");
+			ExtensionMap.Add(".svg", "image/svg-xml");
+			ExtensionMap.Add(".svgz", "image/svg-xml");
 			ExtensionMap.Add(".sv4cpio", "application/x-sv4cpio");
 			ExtensionMap.Add(".swf", "application/x-shockwave-flash");
 			ExtensionMap.Add(".tex", "application/x-tex");


### PR DESCRIPTION
roadkill defaults to application/octet-stream for svg and svgz. This
works under certain circumstances, but fails for others showing a broken
link instead of the image.